### PR TITLE
reconfigure sass process

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,5 @@
 module.exports = function (eleventyConfig) {
-  // Doesn't use .gitignore, so it won't ignore CSS changes
+  // Doesn't use .gitignore
   eleventyConfig.setUseGitIgnore(false);
 
   // Move without doing anything

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,3 @@ _site
 
 # Local Netlify folder
 .netlify
-
-# Ignore compiled Sass
-src/assets/css

--- a/README.md
+++ b/README.md
@@ -37,5 +37,3 @@ NOTE: Sass is kind of wonky. The sourcemaps don’t work (paths are wrong). In t
 `npm run build` builds your awesome site. This is what Netlify will use when they* build your site. It’s set in `netlify.toml`
 
 *I always picture someone at Netlify getting a message from a pneumatic tube that I want to deploy a site. A bell rings. That message gets handed off to many people. Then my code goes down an assembly line.
-
-I don’t expect anyone will use or read this, but if you have any questions or comments, please file an issue, email me, DM me, or any other text based communication. I do not like using the phone.

--- a/package.json
+++ b/package.json
@@ -4,20 +4,16 @@
   "description": "Basic skeleton for a site built with Eleventy, Sass, and deployed by Netlify",
   "main": "index.js",
   "scripts": {
-    "sass:build": "sass src/scss:src/assets/css --style=compressed --no-source-map",
-    "sass:serve": "sass src/scss:src/assets/css --color --embed-sources --watch",
+    "sass:build": "sass src/scss:_site/assets/css --style=compressed --no-source-map",
+    "sass:serve": "sass src/scss:_site/assets/css --color --embed-sources --watch",
     "eleventy:serve": "ELEVENTY_ENV=development eleventy --serve",
     "debug": "DEBUG=Eleventy* npx eleventy --dryrun",
     "performance": "DEBUG=Eleventy:Benchmark* eleventy",
-    "clean": "rm -rf src/assets/css _site",
-    "start": "npm run clean && npm run sass:build && concurrently \"npm run eleventy:serve\" \"npm run sass:serve\"",
-    "build": "npm run sass:build && eleventy",
-    "build:dev": "sass src/scss:src/assets/css --color --embed-sources && eleventy"
+    "clean": "rm -rf _site",
+    "start": "npm run clean && concurrently \"npm run eleventy:serve\" \"npm run sass:serve\"",
+    "build": "npm run sass:build && eleventy"
   },
-  "keywords": [
-    "Eleventy",
-    "Sass"
-  ],
+  "keywords": [],
   "author": "S.R. Wild",
   "license": "ISC",
   "devDependencies": {


### PR DESCRIPTION
Refactors the clunky way I had Sass setup. Before, Eleventy would build when an scss files changed. Now, Sass compiling is separate from Eleventy. BrowserSync will reload when an scss file changes, not only when an Eleventy watched file changes. 